### PR TITLE
Iter2 bugs mapper sanitize strings

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/search/CurrencySymbols.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/CurrencySymbols.kt
@@ -1,0 +1,14 @@
+package ru.practicum.android.diploma.data.search
+
+object CurrencySymbols {
+    const val RUB = "₽"
+    const val BYN = "Br"
+    const val USD = "$"
+    const val EUR = "€"
+    const val KZT = "₸"
+    const val UAH = "₴"
+    const val AZN = "₼"
+    const val UZS = "сўм"
+    const val GEL = "₾"
+    const val KGT = "сом"
+}

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/SearchVacanciesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/SearchVacanciesRepositoryImpl.kt
@@ -24,19 +24,19 @@ class SearchVacanciesRepositoryImpl(
     override fun searchVacancies(filter: VacancySearchFilter): Flow<VacancySearchResult> = flow {
         val savedFilters = filterRepository.getFilters()
         val queryMap = mutableMapOf<String, String>().apply {
-            put("text", filter.text ?: "")
-            put("page", filter.page.toString())
+            put(KEY_TEXT, filter.text ?: EMPTY_STRING)
+            put(KEY_PAGE, filter.page.toString())
 
             savedFilters.industryId?.let {
-                put("industry", it.toString())
+                put(KEY_INDUSTRY, it.toString())
             }
 
             savedFilters.salaryFrom?.let {
-                put("salary", it.toString())
+                put(KEY_SALARY, it.toString())
             }
 
             if (savedFilters.onlyWithSalary) {
-                put("only_with_salary", "true")
+                put(KEY_ONLY_WITH_SALARY, VALUE_TRUE)
             }
         }
         val response = networkClient.doRequest(VacancyRequest(queryMap))
@@ -70,4 +70,14 @@ class SearchVacanciesRepositoryImpl(
             }
         }
     }.flowOn(Dispatchers.IO)
+
+    companion object {
+        private const val KEY_TEXT = "text"
+        private const val KEY_PAGE = "page"
+        private const val KEY_INDUSTRY = "industry"
+        private const val KEY_SALARY = "salary"
+        private const val KEY_ONLY_WITH_SALARY = "only_with_salary"
+        private const val VALUE_TRUE = "true"
+        private const val EMPTY_STRING = ""
+    }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/SearchVacanciesRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/SearchVacanciesRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package ru.practicum.android.diploma.data.search
 
+import android.content.res.Resources
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -16,7 +17,8 @@ import ru.practicum.android.diploma.domain.models.VacancySearchResult
 
 class SearchVacanciesRepositoryImpl(
     private val networkClient: NetworkClient,
-    private val filterRepository: FilterRepository
+    private val filterRepository: FilterRepository,
+    private val resources: Resources
 ) : SearchVacanciesRepository {
 
     override fun searchVacancies(filter: VacancySearchFilter): Flow<VacancySearchResult> = flow {
@@ -42,8 +44,10 @@ class SearchVacanciesRepositoryImpl(
             NetworkCodes.SUCCESS_CODE -> {
                 val vacanciesResponse = response as VacancyResponse
                 val vacancies: List<Vacancy> =
-                    VacancyDtoMapper.mapList(vacanciesResponse.vacancies)
-
+                    VacancyDtoMapper.mapList(
+                        vacanciesResponse.vacancies,
+                        resources
+                    )
                 emit(
                     VacancySearchResult(
                         totalFound = vacanciesResponse.found,

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt
@@ -5,6 +5,16 @@ import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.data.dto.PhoneDto
 import ru.practicum.android.diploma.data.dto.Salary
 import ru.practicum.android.diploma.data.dto.VacancyDto
+import ru.practicum.android.diploma.data.search.CurrencySymbols.AZN
+import ru.practicum.android.diploma.data.search.CurrencySymbols.BYN
+import ru.practicum.android.diploma.data.search.CurrencySymbols.EUR
+import ru.practicum.android.diploma.data.search.CurrencySymbols.GEL
+import ru.practicum.android.diploma.data.search.CurrencySymbols.KGT
+import ru.practicum.android.diploma.data.search.CurrencySymbols.KZT
+import ru.practicum.android.diploma.data.search.CurrencySymbols.RUB
+import ru.practicum.android.diploma.data.search.CurrencySymbols.UAH
+import ru.practicum.android.diploma.data.search.CurrencySymbols.USD
+import ru.practicum.android.diploma.data.search.CurrencySymbols.UZS
 import ru.practicum.android.diploma.domain.models.Vacancy
 import java.util.Locale
 
@@ -88,16 +98,16 @@ object VacancyDtoMapper {
 
     private fun getCurrencySymbol(currencyCode: String): String {
         return when (currencyCode.uppercase()) {
-            "RUR", "RUB" -> "₽"
-            "BYR" -> "Br"
-            "USD" -> "$"
-            "EUR" -> "€"
-            "KZT" -> "₸"
-            "UAH" -> "₴"
-            "AZN" -> "₼"
-            "UZS" -> "сўм"
-            "GEL" -> "₾"
-            "KGT" -> "сом"
+            "RUR", "RUB" -> RUB
+            "BYR" -> BYN
+            "USD" -> USD
+            "EUR" -> EUR
+            "KZT" -> KZT
+            "UAH" -> UAH
+            "AZN" -> AZN
+            "UZS" -> UZS
+            "GEL" -> GEL
+            "KGT" -> KGT
             else -> currencyCode
         }
     }

--- a/app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt
@@ -1,5 +1,7 @@
 package ru.practicum.android.diploma.data.search
 
+import android.content.res.Resources
+import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.data.dto.PhoneDto
 import ru.practicum.android.diploma.data.dto.Salary
 import ru.practicum.android.diploma.data.dto.VacancyDto
@@ -7,7 +9,7 @@ import ru.practicum.android.diploma.domain.models.Vacancy
 import java.util.Locale
 
 object VacancyDtoMapper {
-    fun map(dto: VacancyDto): Vacancy {
+    fun map(dto: VacancyDto, resources: Resources): Vacancy {
         val displayName = formatName(dto.name, dto.address?.city, dto.area.name)
 
         return Vacancy(
@@ -24,7 +26,7 @@ object VacancyDtoMapper {
             salaryFrom = dto.salary?.from,
             salaryTo = dto.salary?.to,
             currency = dto.salary?.currency,
-            salaryTitle = formatSalary(dto.salary),
+            salaryTitle = formatSalary(dto.salary, resources),
             city = dto.address?.city,
             street = dto.address?.street,
             building = dto.address?.building,
@@ -38,40 +40,41 @@ object VacancyDtoMapper {
         )
     }
 
-    fun mapList(dtoList: List<VacancyDto>?): List<Vacancy> {
-        return dtoList?.map { map(it) } ?: emptyList()
+    fun mapList(
+        dtoList: List<VacancyDto>?,
+        resources: Resources
+    ): List<Vacancy> {
+        return dtoList?.map { map(it, resources) } ?: emptyList()
     }
 
-    fun formatSalary(salary: Salary?): String {
-        return if (salary != null) {
-            buildString {
-                val formattedFrom = salary.from?.let { formatNumber(it) }
-                val formattedTo = salary.to?.let { formatNumber(it) }
-
-                when {
-                    formattedFrom != null && formattedTo != null ->
-                        append("От $formattedFrom до $formattedTo")
-
-                    formattedFrom != null ->
-                        append("От $formattedFrom")
-
-                    formattedTo != null ->
-                        append("До $formattedTo")
-
-                    else ->
-                        return "Зарплата не указана"
-                }
-
-                salary.currency?.let { currency ->
-                    if (currency.isNotBlank()) {
-                        append(" ")
-                        append(getCurrencySymbol(currency))
-                    }
-                }
-            }
-        } else {
-            "Зарплата не указана"
+    fun formatSalary(
+        salary: Salary?,
+        resources: Resources
+    ): String {
+        if (salary == null) {
+            return resources.getString(R.string.salary_not_specified)
         }
+
+        val from = salary.from?.let { formatNumber(it) }
+        val to = salary.to?.let { formatNumber(it) }
+
+        val base = when {
+            from != null && to != null ->
+                resources.getString(R.string.salary_from_to, from, to)
+
+            from != null ->
+                resources.getString(R.string.salary_from, from)
+
+            to != null ->
+                resources.getString(R.string.salary_to, to)
+
+            else ->
+                resources.getString(R.string.salary_not_specified)
+        }
+
+        return salary.currency?.let { currency ->
+            "$base ${getCurrencySymbol(currency)}"
+        } ?: base
     }
 
     fun formatName(name: String, city: String?, areaName: String): String {

--- a/app/src/main/java/ru/practicum/android/diploma/data/vacancy/VacancyDetailsRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/vacancy/VacancyDetailsRepositoryImpl.kt
@@ -33,7 +33,7 @@ class VacancyDetailsRepositoryImpl(
         return when (response.resultCode) {
             NetworkCodes.SUCCESS_CODE -> {
                 val detailsResponce = response as VacancyDetailsResponse
-                val vacancy = VacancyDtoMapper.map(detailsResponce.vacancy)
+                val vacancy = VacancyDtoMapper.map(detailsResponce.vacancy, context.resources)
                 VacancyDetailsSearchResult(vacancy, null)
             }
 

--- a/app/src/main/java/ru/practicum/android/diploma/di/RepositoryModule.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/di/RepositoryModule.kt
@@ -16,7 +16,7 @@ import ru.practicum.android.diploma.domain.api.VacancyDetailsRepository
 
 val repositoryModule = module {
     single<SearchVacanciesRepository> {
-        SearchVacanciesRepositoryImpl(get(), get<FilterRepository>())
+        SearchVacanciesRepositoryImpl(get(), get<FilterRepository>(), androidContext().resources)
     }
     single<VacancyDetailsRepository> {
         VacancyDetailsRepositoryImpl(get(), get(), androidContext())

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/SearchVacanciesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/SearchVacanciesInteractorImpl.kt
@@ -15,8 +15,19 @@ class SearchVacanciesInteractorImpl(private val repository: SearchVacanciesRepos
         return repository.searchVacancies(sanitizedFilters)
     }
 
+    /**
+     * Легкая очистка на клиентской стороне:
+     * - Удаляем управляющие и необычные символы
+     * - Сводим несколько пробелов к одному
+     *
+     * ВНИМАНИЕ: это "не полная очистка". На сервере выполняется
+     * полноценная нормализация, фильтрация и проверка безопасности.
+     */
     private fun sanitizeText(text: String): String {
-        return text.replace(Regex("[^\\p{L}\\p{N}.&\\-'/ ]+"), "")
+        return text
+            // Оставляем буквы, цифры, базовую пунктуацию и пробелы
+            .replace(Regex("[^\\p{L}\\p{N}.&\\-'/ ]+"), "")
+            // Сводим несколько пробелов к одному
             .replace(Regex("\\s+"), " ")
             .trim()
     }

--- a/app/src/main/java/ru/practicum/android/diploma/domain/impl/SearchVacanciesInteractorImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/impl/SearchVacanciesInteractorImpl.kt
@@ -10,25 +10,9 @@ class SearchVacanciesInteractorImpl(private val repository: SearchVacanciesRepos
     SearchVacanciesInteractor {
     override fun searchVacancies(filters: VacancySearchFilter): Flow<VacancySearchResult> {
         val sanitizedFilters = filters.copy(
-            text = filters.text?.let { sanitizeText(it) }
+            text = filters.text?.let { it }
         )
         return repository.searchVacancies(sanitizedFilters)
     }
 
-    /**
-     * Легкая очистка на клиентской стороне:
-     * - Удаляем управляющие и необычные символы
-     * - Сводим несколько пробелов к одному
-     *
-     * ВНИМАНИЕ: это "не полная очистка". На сервере выполняется
-     * полноценная нормализация, фильтрация и проверка безопасности.
-     */
-    private fun sanitizeText(text: String): String {
-        return text
-            // Оставляем буквы, цифры, базовую пунктуацию и пробелы
-            .replace(Regex("[^\\p{L}\\p{N}.&\\-'/ ]+"), "")
-            // Сводим несколько пробелов к одному
-            .replace(Regex("\\s+"), " ")
-            .trim()
-    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,8 @@
     <string name="duties">Обязанности</string>
     <string name="requirements">Требования</string>
     <string name="conditions">Условия</string>
+
+    <string name="salary_from_to">От %1$s до %2$s</string>
+    <string name="salary_from">От %1$s</string>
+    <string name="salary_to">До %1$s</string>
 </resources>


### PR DESCRIPTION
1. app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt line 52-62
Эти строчки должны быть вынесены в ресурсы приложения, так как они должны локализоваться. Для строк с аргументами можно использовать экранирование строк, андроид это поддерживает
2. app/src/main/java/ru/practicum/android/diploma/data/search/SearchVacanciesRepositoryImpl.kt line 23
Ключи лучше вынести в константы для повышения читабельности кода
3. app/src/main/java/ru/practicum/android/diploma/data/search/VacancyDtoMapper.kt line 88-97
Символы валют лучше в константы вынести в отдельном файле
4. app/src/main/java/ru/practicum/android/diploma/domain/impl/SearchVacanciesInteractorImpl.kt
sanitize подразумевает гораздо больше замен, чем вы реализовали. Обычно эта логика реализуется на серверной стороне, а клиент отсылает сырой query