### PR TITLE
Iter3 bugs 1

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
@@ -8,11 +8,13 @@ import ru.practicum.android.diploma.domain.api.IndustryRepository
 import ru.practicum.android.diploma.domain.models.Industry
 import ru.practicum.android.diploma.domain.models.IndustrySearchError
 import ru.practicum.android.diploma.domain.models.IndustrySearchResult
+import kotlin.coroutines.cancellation.CancellationException
 
 class IndustryRepositoryImpl(private val networkClient: NetworkClient) : IndustryRepository {
     override suspend fun getIndustries(): IndustrySearchResult {
         return try {
             val response = networkClient.doRequest(IndustryRequest())
+
             when (response.resultCode) {
                 NetworkCodes.SERVER_ERROR_CODE -> {
                     IndustrySearchResult(null, IndustrySearchError.Server)
@@ -30,7 +32,9 @@ class IndustryRepositoryImpl(private val networkClient: NetworkClient) : Industr
                     IndustrySearchResult(null, IndustrySearchError.Network)
                 }
             }
-        } catch (_: Exception) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             IndustrySearchResult(null, IndustrySearchError.Network)
         }
     }

--- a/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
@@ -8,6 +8,7 @@ import ru.practicum.android.diploma.domain.api.IndustryRepository
 import ru.practicum.android.diploma.domain.models.Industry
 import ru.practicum.android.diploma.domain.models.IndustrySearchError
 import ru.practicum.android.diploma.domain.models.IndustrySearchResult
+import java.io.IOException
 import kotlin.coroutines.cancellation.CancellationException
 
 class IndustryRepositoryImpl(private val networkClient: NetworkClient) : IndustryRepository {
@@ -16,9 +17,8 @@ class IndustryRepositoryImpl(private val networkClient: NetworkClient) : Industr
             val response = networkClient.doRequest(IndustryRequest())
 
             when (response.resultCode) {
-                NetworkCodes.SERVER_ERROR_CODE -> {
+                NetworkCodes.SERVER_ERROR_CODE ->
                     IndustrySearchResult(null, IndustrySearchError.Server)
-                }
 
                 NetworkCodes.SUCCESS_CODE -> {
                     val industryResponse = response as IndustryResponse
@@ -28,13 +28,13 @@ class IndustryRepositoryImpl(private val networkClient: NetworkClient) : Industr
                     IndustrySearchResult(data, null)
                 }
 
-                else -> {
+                else ->
                     IndustrySearchResult(null, IndustrySearchError.Network)
-                }
             }
+
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
+        } catch (e: IOException) {
             IndustrySearchResult(null, IndustrySearchError.Network)
         }
     }

--- a/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt
@@ -8,34 +8,28 @@ import ru.practicum.android.diploma.domain.api.IndustryRepository
 import ru.practicum.android.diploma.domain.models.Industry
 import ru.practicum.android.diploma.domain.models.IndustrySearchError
 import ru.practicum.android.diploma.domain.models.IndustrySearchResult
-import java.io.IOException
-import kotlin.coroutines.cancellation.CancellationException
 
 class IndustryRepositoryImpl(private val networkClient: NetworkClient) : IndustryRepository {
     override suspend fun getIndustries(): IndustrySearchResult {
-        return try {
-            val response = networkClient.doRequest(IndustryRequest())
-
-            when (response.resultCode) {
-                NetworkCodes.SERVER_ERROR_CODE ->
-                    IndustrySearchResult(null, IndustrySearchError.Server)
-
-                NetworkCodes.SUCCESS_CODE -> {
-                    val industryResponse = response as IndustryResponse
-                    val data = industryResponse.industries.map {
-                        Industry(it.id, it.name)
-                    }
-                    IndustrySearchResult(data, null)
+        val response = networkClient.doRequest(IndustryRequest())
+        return when (response.resultCode) {
+            NetworkCodes.SUCCESS_CODE -> {
+                val industryResponse = response as IndustryResponse
+                val data = industryResponse.industries.map {
+                    Industry(it.id, it.name)
                 }
-
-                else ->
-                    IndustrySearchResult(null, IndustrySearchError.Network)
+                IndustrySearchResult(data, null)
             }
 
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: IOException) {
-            IndustrySearchResult(null, IndustrySearchError.Network)
+            NetworkCodes.SERVER_ERROR_CODE ->
+                IndustrySearchResult(null, IndustrySearchError.Server)
+
+            NetworkCodes.NO_NETWORK_CODE,
+            NetworkCodes.TIMEOUT_CODE ->
+                IndustrySearchResult(null, IndustrySearchError.Network)
+
+            else ->
+                IndustrySearchResult(null, IndustrySearchError.Network)
         }
     }
 }

--- a/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/data/network/RetrofitNetworkClient.kt
@@ -34,9 +34,11 @@ class RetrofitNetworkClient(private val context: Context, private val service: V
                 resultCode = NetworkCodes.SUCCESS_CODE
             }
         } catch (e: HttpException) {
-            Response().apply {
-                resultCode = e.code()
-            }
+            createErrorResponse(e.code())
+        } catch (_: SocketTimeoutException) {
+            createErrorResponse(NetworkCodes.TIMEOUT_CODE)
+        } catch (_: IOException) {
+            createErrorResponse(NetworkCodes.NO_NETWORK_CODE)
         }
     }
 

--- a/app/src/main/java/ru/practicum/android/diploma/domain/models/IndustrySearchError.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/domain/models/IndustrySearchError.kt
@@ -1,6 +1,6 @@
 package ru.practicum.android.diploma.domain.models
 
-sealed class IndustrySearchError {
-    object Network : IndustrySearchError()
-    object Server : IndustrySearchError()
+sealed interface IndustrySearchError {
+    object Network : IndustrySearchError
+    object Server : IndustrySearchError
 }

--- a/app/src/main/java/ru/practicum/android/diploma/ui/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/favorites/FavoritesViewModel.kt
@@ -22,13 +22,8 @@ class FavoritesViewModel(
     private val _state = MutableLiveData<FavoritesState>()
     val state: LiveData<FavoritesState> = _state
 
-    /*    init {
-            loadFavorites()
-        }*/
-
     fun loadFavorites() {
         viewModelScope.launch {
-            // _state.value = FavoritesState.Loading
             try {
                 val favorites = favoritesInteractor.getAllFavorites()
                 _state.value = if (favorites.isEmpty()) {

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/IndustryViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/IndustryViewModel.kt
@@ -27,19 +27,13 @@ class IndustryViewModel(
     private var loadJob: Job? = null
     fun loadIndustries() {
         _stateLiveData.value = IndustryState.Loading
-
         loadJob?.cancel()
-
         loadJob = viewModelScope.launch {
-
             allIndustries.clear()
-
             val response = industryInteractor.getIndustries()
-
             val data = response.data
                 ?.sortedBy { it.name.lowercase(Locale.getDefault()) }
                 ?: emptyList()
-
             allIndustries.addAll(data)
 
             val savedFilters = filterInteractor.getFilters()
@@ -65,10 +59,8 @@ class IndustryViewModel(
                     _stateLiveData.postValue(
                         IndustryState.Error(response.error)
                     )
-
                 data.isEmpty() ->
                     _stateLiveData.postValue(IndustryState.Empty)
-
                 else ->
                     _stateLiveData.postValue(
                         IndustryState.Content(data)

--- a/app/src/main/java/ru/practicum/android/diploma/ui/filter/IndustryViewModel.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/ui/filter/IndustryViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import ru.practicum.android.diploma.domain.api.FilterInteractor
 import ru.practicum.android.diploma.domain.api.IndustryInteractor
@@ -23,13 +24,18 @@ class IndustryViewModel(
     private val _isButtonEnabled = MutableLiveData(false)
     val isButtonEnabled: LiveData<Boolean> = _isButtonEnabled
     private var selectedIndustryName: String? = null
+    private var loadJob: Job? = null
     fun loadIndustries() {
         _stateLiveData.value = IndustryState.Loading
 
-        viewModelScope.launch {
+        loadJob?.cancel()
+
+        loadJob = viewModelScope.launch {
+
             allIndustries.clear()
 
             val response = industryInteractor.getIndustries()
+
             val data = response.data
                 ?.sortedBy { it.name.lowercase(Locale.getDefault()) }
                 ?: emptyList()
@@ -42,7 +48,8 @@ class IndustryViewModel(
             selectedIndustryName = savedFilters.industryName
 
             if (savedIndustryId != null) {
-                selectedIndustryName = allIndustries.find { it.id == savedIndustryId }?.name
+                selectedIndustryName =
+                    allIndustries.find { it.id == savedIndustryId }?.name
             }
 
             if (savedIndustryId != null &&
@@ -55,14 +62,19 @@ class IndustryViewModel(
 
             when {
                 response.error != null ->
-                    _stateLiveData.postValue(IndustryState.Error(response.error))
+                    _stateLiveData.postValue(
+                        IndustryState.Error(response.error)
+                    )
 
                 data.isEmpty() ->
                     _stateLiveData.postValue(IndustryState.Empty)
 
                 else ->
-                    _stateLiveData.postValue(IndustryState.Content(data))
+                    _stateLiveData.postValue(
+                        IndustryState.Content(data)
+                    )
             }
+
             updateButtonEnabled()
         }
     }
@@ -118,5 +130,9 @@ class IndustryViewModel(
         selectedIndustryId = industryToSave
         selectedIndustryName = industryNameToSave
         updateButtonEnabled()
+    }
+    override fun onCleared() {
+        super.onCleared()
+        loadJob?.cancel()
     }
 }


### PR DESCRIPTION
app/src/main/java/ru/practicum/android/diploma/data/filter/IndustryRepositoryImpl.kt line 33
При использовании корутин не рекомендуется отлавливать ошибку используя класс Exception в try-catch, т.к. в корутинах есть специальный класс CancellationException, который используется механизмом отмены корутин и если его отловить и не перевыбросить - ломается отмена корутины. В корутинах есть отдельный механизм обработки ошибок через CoroutineExceptionHandler - элемент контекста корутины, либо можно добавить обработку CancellationException и пробросить его выше используя ключевое слово throw
app/src/main/java/ru/practicum/android/diploma/domain/models/IndustrySearchError.kt line 3
Здесь больше подойдёт sealed interface, т.к. преимущества класса здесь не используются
app/src/main/java/ru/practicum/android/diploma/ui/filter/IndustryViewModel.kt line 26-29
Тут стоит результат вызова launch сохранить в объект Job и отменять предыдущую корутину перед запуском новой, чтобы гарантировать, что в один момент времени только 1 корутина будет загружать данные
app/src/main/java/ru/practicum/android/diploma/ui/favorites/FavoritesViewModel.kt line 25
line 31
Закоментированный код лучше сразу удалять. Хранить закоментированный код в проекте - плохая практика, в случае чего этот код можно восстановить с помощью истории гита